### PR TITLE
changing hyphenated info to underscore and capitalised

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ async function run_action()
                 core.debug(`parsedValue: ${parsedValue}`);
                 // Set environment variable with ssmPath name as the env variable
                 var split = param.Name.split('/');
-                var envVarName = prefix + split[split.length - 1];
+                var envVarName = prefix + split[split.length - 1].toUpperCase().replace(/-/g, '_');
                 core.debug(`Using prefix + end of ssmPath for env var name: ${envVarName}`);
                 setEnvironmentVar(envVarName, parsedValue, maskValues);
             }


### PR DESCRIPTION

I had to make changes to a published action as the way the ssm params is exported as ENV fails on bash.

Right now `/staging/patientapp/gch/base-url` is exported as `base-url` while we want to change it to `BASE_URL`